### PR TITLE
fix(emotion-primitives): put back missing dependency for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "flow-bin": "^0.61.0",
     "gatsby-react-router-scroll": "^1.0.7",
+    "get-lerna-packages": "^0.1.0",
     "hoist-non-react-statics": "^2.3.1",
     "jest": "^21.2.1",
     "jest-cli": "^20.0.4",


### PR DESCRIPTION
This is breaking the tests right now - we can put this back for the time being to focus on surfacing other issues which I think you're doing already